### PR TITLE
Add `partition` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,11 @@ module.exports = options => {
 	electron.protocol.registerStandardSchemes([options.scheme], {secure: true});
 
 	electron.app.on('ready', () => {
-		electron.protocol.registerFileProtocol(options.scheme, handler, error => {
+		const ses = options.partition ?
+			electron.session.fromPartition(options.partition) :
+			electron.session.defaultSession;
+
+		ses.protocol.registerFileProtocol(options.scheme, handler, error => {
 			if (error) {
 				throw error;
 			}

--- a/index.js
+++ b/index.js
@@ -47,11 +47,11 @@ module.exports = options => {
 	electron.protocol.registerStandardSchemes([options.scheme], {secure: true});
 
 	electron.app.on('ready', () => {
-		const ses = options.partition ?
+		const session = options.partition ?
 			electron.session.fromPartition(options.partition) :
 			electron.session.defaultSession;
 
-		ses.protocol.registerFileProtocol(options.scheme, handler, error => {
+		session.protocol.registerFileProtocol(options.scheme, handler, error => {
 			if (error) {
 				throw error;
 			}

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@ Custom scheme. For example, `foo` results in your `directory` being available at
 #### partition
 
 Type: `string`<br>
+Default: [`electron.session.defaultSession`](https://electronjs.org/docs/api/session#sessiondefaultsession)
 
 The [partition](https://electronjs.org/docs/api/session#sessionfrompartitionpartition-options) the protocol should be installed to, if you're not using Electron's default partition.
 

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,11 @@ Default: `app`
 
 Custom scheme. For example, `foo` results in your `directory` being available at `foo://-`.
 
+#### partition
+
+Type: `string`<br>
+
+The partition the protocol should be installed to, if you're not using electron's default partition.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,8 @@ Custom scheme. For example, `foo` results in your `directory` being available at
 
 Type: `string`<br>
 
-The partition the protocol should be installed to, if you're not using electron's default partition.
+The [partition](https://electronjs.org/docs/api/session#sessionfrompartitionpartition-options) the protocol should be installed to, if you're not using Electron's default partition.
+
 
 ## Related
 


### PR DESCRIPTION
If using a custom partition (very useful for tests), the protocol needs to be registered on it specifically