### PR TITLE
Fix Electron 5 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = options => {
 	} else {
 		// Electron >= 5.x
 		electron.protocol.registerSchemesAsPrivileged([
-			{scheme: options.scheme, privileges: {secure: true,standard:true}}
+			{scheme: options.scheme, privileges: {secure: true, standard: true}}
 		]);
 	}
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const getPath = async pth => {
 		if (result.isDirectory()) {
 			return getPath(path.join(pth, 'index.html'));
 		}
-	} catch (err) {}
+	} catch (error) {}
 };
 
 module.exports = options => {
@@ -44,14 +44,14 @@ module.exports = options => {
 
 	if (electron.protocol.registerStandardSchemes) {
 		// Electron <= 4.x
-		electron.protocol.registerStandardSchemes([options.scheme], { secure: true });
+		electron.protocol.registerStandardSchemes([options.scheme], {secure: true});
 	} else {
 		// Electron >= 5.x
 		electron.protocol.registerSchemesAsPrivileged([
-			{ scheme: options.scheme, privileges: { secure: true } }
-		])
+			{scheme: options.scheme, privileges: {secure: true}}
+		]);
 	}
-	
+
 	electron.app.on('ready', () => {
 		const session = options.partition ?
 			electron.session.fromPartition(options.partition) :

--- a/index.js
+++ b/index.js
@@ -42,8 +42,16 @@ module.exports = options => {
 		});
 	};
 
-	electron.protocol.registerStandardSchemes([options.scheme], {secure: true});
-
+	if (electron.protocol.registerStandardSchemes) {
+		// Electron <= 4.x
+		electron.protocol.registerStandardSchemes([options.scheme], { secure: true });
+	} else {
+		// Electron >= 5.x
+		electron.protocol.registerSchemesAsPrivileged([
+			{ scheme: options.scheme, privileges: { secure: true } }
+		])
+	}
+	
 	electron.app.on('ready', () => {
 		const session = options.partition ?
 			electron.session.fromPartition(options.partition) :

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = options => {
 	} else {
 		// Electron >= 5.x
 		electron.protocol.registerSchemesAsPrivileged([
-			{scheme: options.scheme, privileges: {secure: true}}
+			{scheme: options.scheme, privileges: {secure: true,standard:true}}
 		]);
 	}
 


### PR DESCRIPTION
As specified on Electron repo at [protocol.md](https://github.com/electron/electron/blob/master/docs/api/protocol.md#protocolregisterschemesasprivilegedcustomschemes) the method registerStandardSchemes is no longer available on Electron 5.x.

This change checks if that method exists so won't break compatibility with < 5.x