### PR TITLE
Fix race issue with protocol registration

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,9 +65,7 @@ module.exports = options => {
 		]);
 	}
 
-	(async () => {
-		await electron.app.whenReady();
-
+	electron.app.on('ready', () => {
 		const session = options.partition ?
 			electron.session.fromPartition(options.partition) :
 			electron.session.defaultSession;
@@ -77,7 +75,7 @@ module.exports = options => {
 				throw error;
 			}
 		});
-	})();
+	});
 
 	return async win => {
 		await win.loadURL(`${options.scheme}://-`);

--- a/test/fixture-on-ready.js
+++ b/test/fixture-on-ready.js
@@ -1,0 +1,12 @@
+'use strict';
+const {app, BrowserWindow} = require('electron');
+const serve = require('..');
+
+const loadUrl = serve({directory: __dirname});
+
+let mainWindow;
+
+app.on('ready', () => {
+	mainWindow = new BrowserWindow();
+	loadUrl(mainWindow);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,18 @@ test('serves directory index', async t => {
 	t.pass();
 });
 
+test('serves directory index on app ready', async t => {
+	t.context.spectron = new Application({
+		path: electron,
+		args: ['fixture-on-ready.js']
+	});
+	await t.context.spectron.start();
+	const {client} = t.context.spectron;
+	await client.waitUntilWindowLoaded();
+	await client.waitUntilTextExists('h1', '🦄', 5000);
+	t.pass();
+});
+
 test('allows special characters in file paths', async t => {
 	t.context.spectron = new Application({
 		path: electron,


### PR DESCRIPTION
_app.on('ready')_ is fired before _app.waitReady_ and allows the protocol to be registered earlier.

Should fix #15 and fix #18 