### PR TITLE
Fix deprecation message in Electron 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = options => {
 			electron.session.fromPartition(options.partition) :
 			electron.session.defaultSession;
 		const major = process.versions.electron.split('.')[0];
-		if (major > "6") {
+		if (major > '6') {
 			// https://github.com/electron/electron/blob/7-0-x/docs/api/breaking-changes-ns.md
 			session.protocol.registerFileProtocol(options.scheme, handler);
 		} else {

--- a/index.js
+++ b/index.js
@@ -69,8 +69,8 @@ module.exports = options => {
 		const session = options.partition ?
 			electron.session.fromPartition(options.partition) :
 			electron.session.defaultSession;
-		const electronMajorVersion = Number.parseInt(process.versions.electron.split('.')[0]);
-		if (major >= 7) {
+		const electronMajorVersion = Number.parseInt(process.versions.electron.split('.')[0], 10);
+		if (electronMajorVersion >= 7) {
 			// https://github.com/electron/electron/blob/7-0-x/docs/api/breaking-changes-ns.md
 			session.protocol.registerFileProtocol(options.scheme, handler);
 		} else {

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = options => {
 			electron.session.fromPartition(options.partition) :
 			electron.session.defaultSession;
 		const electronMajorVersion = Number.parseInt(process.versions.electron.split('.')[0]);
-		if (major > '6') {
+		if (major >= 7) {
 			// https://github.com/electron/electron/blob/7-0-x/docs/api/breaking-changes-ns.md
 			session.protocol.registerFileProtocol(options.scheme, handler);
 		} else {

--- a/index.js
+++ b/index.js
@@ -69,12 +69,17 @@ module.exports = options => {
 		const session = options.partition ?
 			electron.session.fromPartition(options.partition) :
 			electron.session.defaultSession;
-
-		session.protocol.registerFileProtocol(options.scheme, handler, error => {
-			if (error) {
-				throw error;
-			}
-		});
+		const major = process.versions.electron.split('.')[0];
+		if (major > "6") {
+			// https://github.com/electron/electron/blob/7-0-x/docs/api/breaking-changes-ns.md
+			session.protocol.registerFileProtocol(options.scheme, handler);
+		} else {
+			session.protocol.registerFileProtocol(options.scheme, handler, error => {
+				if (error) {
+					throw error;
+				}
+			});
+		}
 	});
 
 	return async win => {

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = options => {
 		const session = options.partition ?
 			electron.session.fromPartition(options.partition) :
 			electron.session.defaultSession;
-		const major = process.versions.electron.split('.')[0];
+		const electronMajorVersion = Number.parseInt(process.versions.electron.split('.')[0]);
 		if (major > '6') {
 			// https://github.com/electron/electron/blob/7-0-x/docs/api/breaking-changes-ns.md
 			session.protocol.registerFileProtocol(options.scheme, handler);


### PR DESCRIPTION
Handle deprecation warning "ProtocolDeprecateCallback: The callback argument of protocol module APIs is no longer needed."
https://github.com/electron/electron/blob/7-0-x/docs/api/breaking-changes-ns.md