### PR TITLE
Serve `index.html` when in `app.asar`

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,9 @@ module.exports = options => {
 		const indexPath = path.join(options.directory, 'index.html');
 		const filePath = path.join(options.directory, decodeURIComponent(new URL(request.url).pathname));
 		const resolvedPath = await getPath(filePath);
+		const fileExtension = path.extname(filePath);
 
-		if (resolvedPath || !path.extname(filePath) || path.extname(filePath) === '.html') {
+		if (resolvedPath || !fileExtension || fileExtension === '.html' || fileExtension === '.asar') {
 			callback({
 				path: resolvedPath || indexPath
 			});


### PR DESCRIPTION
Steps:
1. Set directory to be "." (e.g. serve from app.asar directly)
2. Bundle an electron app

Expected:
app://- serves index.html

Actual:
extname(".../app.asar") returns .asar, which fails the guard and serves
file not found.