### PR TITLE
Support loading an HTML file with a custom name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,13 @@ declare namespace electronServe {
 		hostname?: string;
 
 		/**
+		Custom html file name. This gets appended with `.html`.
+
+		@default 'index'
+		*/
+		file?: string;
+
+		/**
 		Whether [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) should be enabled.
 		Useful for testing purposes.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare namespace electronServe {
 		hostname?: string;
 
 		/**
-		Custom html file name. This gets appended with `.html`.
+		Custom HTML filename. This gets appended with `.html`.
 
 		@default 'index'
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare namespace electronServe {
 		hostname?: string;
 
 		/**
-		Custom HTML filename. This gets appended with `.html`.
+		Custom HTML filename. This gets appended with `'.html'`.
 
 		@default 'index'
 		*/

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const stat = promisify(fs.stat);
 // See https://cs.chromium.org/chromium/src/net/base/net_error_list.h
 const FILE_NOT_FOUND = -6;
 
-const getPath = async (path_, route) => {
+const getPath = async (path_, file) => {
 	try {
 		const result = await stat(path_);
 
@@ -18,7 +18,7 @@ const getPath = async (path_, route) => {
 		}
 
 		if (result.isDirectory()) {
-			return getPath(path.join(path_, `${route}.html`));
+			return getPath(path.join(path_, `${file}.html`));
 		}
 	} catch (_) {}
 };
@@ -28,7 +28,7 @@ module.exports = options => {
 		isCorsEnabled: true,
 		scheme: 'app',
 		hostname: '-',
-		route: 'index'
+		file: 'index'
 	}, options);
 
 	if (!options.directory) {
@@ -38,9 +38,9 @@ module.exports = options => {
 	options.directory = path.resolve(electron.app.getAppPath(), options.directory);
 
 	const handler = async (request, callback) => {
-		const indexPath = path.join(options.directory, `${options.route}.html`);
+		const indexPath = path.join(options.directory, `${options.file}.html`);
 		const filePath = path.join(options.directory, decodeURIComponent(new URL(request.url).pathname));
-		const resolvedPath = await getPath(filePath, options.route);
+		const resolvedPath = await getPath(filePath, options.file);
 		const fileExtension = path.extname(filePath);
 
 		if (resolvedPath || !fileExtension || fileExtension === '.html' || fileExtension === '.asar') {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const stat = promisify(fs.stat);
 // See https://cs.chromium.org/chromium/src/net/base/net_error_list.h
 const FILE_NOT_FOUND = -6;
 
-const getPath = async path_ => {
+const getPath = async (path_, route) => {
 	try {
 		const result = await stat(path_);
 
@@ -18,7 +18,7 @@ const getPath = async path_ => {
 		}
 
 		if (result.isDirectory()) {
-			return getPath(path.join(path_, 'index.html'));
+			return getPath(path.join(path_, `${route}.html`));
 		}
 	} catch (_) {}
 };
@@ -27,7 +27,8 @@ module.exports = options => {
 	options = Object.assign({
 		isCorsEnabled: true,
 		scheme: 'app',
-		hostname: '-'
+		hostname: '-',
+		route: 'index'
 	}, options);
 
 	if (!options.directory) {
@@ -37,9 +38,9 @@ module.exports = options => {
 	options.directory = path.resolve(electron.app.getAppPath(), options.directory);
 
 	const handler = async (request, callback) => {
-		const indexPath = path.join(options.directory, 'index.html');
+		const indexPath = path.join(options.directory, `${options.route}.html`);
 		const filePath = path.join(options.directory, decodeURIComponent(new URL(request.url).pathname));
-		const resolvedPath = await getPath(filePath);
+		const resolvedPath = await getPath(filePath, options.route);
 		const fileExtension = path.extname(filePath);
 
 		if (resolvedPath || !fileExtension || fileExtension === '.html' || fileExtension === '.asar') {

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,13 @@ Default: `'-'`
 
 Custom hostname.
 
+##### route
+
+Type: `string`\
+Default: `'index'`
+
+Custom html file name. This gets appended with `'.html'`.
+
 ##### isCorsEnabled
 
 Type: `boolean`\

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Default: `'-'`
 
 Custom hostname.
 
-##### route
+##### file
 
 Type: `string`\
 Default: `'index'`

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Custom hostname.
 Type: `string`\
 Default: `'index'`
 
-Custom html file name. This gets appended with `'.html'`.
+Custom HTML filename. This gets appended with `'.html'`.
 
 ##### isCorsEnabled
 

--- a/test/fixture-custom-file.js
+++ b/test/fixture-custom-file.js
@@ -1,0 +1,14 @@
+'use strict';
+const {app, BrowserWindow} = require('electron');
+const serve = require('..');
+
+const loadUrl = serve({directory: __dirname, file: 'owl'});
+
+let mainWindow;
+
+(async () => {
+	await app.whenReady();
+
+	mainWindow = new BrowserWindow();
+	loadUrl(mainWindow);
+})();

--- a/test/owl.html
+++ b/test/owl.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+	</head>
+	<body>
+		<h1>🦉</h1>
+	</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -65,3 +65,15 @@ test('throws error if unresolved path has an extension other than .html', async 
 	await t.throwsAsync(client.waitUntilTextExists('h1', '🦄', 5000));
 	t.pass();
 });
+
+test('serves directory custom file', async t => {
+	t.context.spectron = new Application({
+		path: electron,
+		args: ['fixture-custom-file.js']
+	});
+	await t.context.spectron.start();
+	const {client} = t.context.spectron;
+	await client.waitUntilWindowLoaded();
+	await client.waitUntilTextExists('h1', '🦉', 5000);
+	t.pass();
+});


### PR DESCRIPTION
As discussed in https://github.com/sindresorhus/electron-serve/issues/33, this makes it possible to load a file that isn't called `index.html`, which could be useful if you're serving more than one file. I put this together for my own use but figured it may be useful for others. Feel free to make any changes!