### PR TITLE
Support query params

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ declare namespace electronServe {
 	/**
 	Load the index file in the window.
 	*/
-	type loadURL = (window: BrowserWindow, searchParams?: Object) => Promise<void>;
+	type loadURL = (window: BrowserWindow, searchParameters?: Record<string>) => Promise<void>;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,9 @@ let mainWindow;
 
 	await loadURL(mainWindow);
 
+	// Or optionally with search parameters.
+	await loadURL(mainWindow, {id: 4, foo: 'bar'});
+
 	// The above is equivalent to this:
 	await mainWindow.loadURL('app://-');
 	// The `-` is just the required hostname.

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ declare namespace electronServe {
 	/**
 	Load the index file in the window.
 	*/
-	type loadURL = (window: BrowserWindow, searchParameters?: Record<string>) => Promise<void>;
+	type loadURL = (window: BrowserWindow, searchParameters?: Record<string, string> | URLSearchParams) => Promise<void>;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ declare namespace electronServe {
 	/**
 	Load the index file in the window.
 	*/
-	type loadURL = (window: BrowserWindow) => Promise<void>;
+	type loadURL = (window: BrowserWindow, searchParams?: Object) => Promise<void>;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -72,8 +72,8 @@ module.exports = options => {
 		session.protocol.registerFileProtocol(options.scheme, handler);
 	});
 
-	return async (window_, query) => {
-		const queryString = query ? `?${query}` : '';
-		await window_.loadURL(`${options.scheme}://${options.hostname}${queryString}`);
+	return async (window_, searchParams) => {
+		const qs = searchParams ? '?' + new URLSearchParams(searchParams).toString() : ''
+		await window_.loadURL(`${options.scheme}://${options.hostname}${qs}`);
 	};
 };

--- a/index.js
+++ b/index.js
@@ -72,8 +72,8 @@ module.exports = options => {
 		session.protocol.registerFileProtocol(options.scheme, handler);
 	});
 
-	return async (window_, searchParams) => {
-		const qs = searchParams ? '?' + new URLSearchParams(searchParams).toString() : ''
+	return async (window_, searchParameters) => {
+		const qs = searchParameters ? '?' + new URLSearchParams(searchParameters).toString() : '';
 		await window_.loadURL(`${options.scheme}://${options.hostname}${qs}`);
 	};
 };

--- a/index.js
+++ b/index.js
@@ -72,7 +72,8 @@ module.exports = options => {
 		session.protocol.registerFileProtocol(options.scheme, handler);
 	});
 
-	return async window_ => {
-		await window_.loadURL(`${options.scheme}://${options.hostname}`);
+	return async (window_, query) => {
+		const queryString = query ? `?${query}` : '';
+		await window_.loadURL(`${options.scheme}://${options.hostname}${queryString}`);
 	};
 };

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = options => {
 	});
 
 	return async (window_, searchParameters) => {
-		const qs = searchParameters ? '?' + new URLSearchParams(searchParameters).toString() : '';
-		await window_.loadURL(`${options.scheme}://${options.hostname}${qs}`);
+		const queryString = searchParameters ? '?' + new URLSearchParams(searchParameters).toString() : '';
+		await window_.loadURL(`${options.scheme}://${options.hostname}${queryString}`);
 	};
 };

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ The `serve` function returns a `loadUrl` function, which you use to serve your H
 ##### window
 
 *Required*\
-Type: `BrowserWindow`\
+Type: `BrowserWindow`
 
 The window to load the file in.
 

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ let mainWindow;
 
 	await loadURL(mainWindow);
 	// Or optionally with query params
-	await loadURL(mainWindow, 'id=4&foo=bar');
+	await loadURL(mainWindow, {id: 4, foo: 'bar'});
 
 	// The above is equivalent to this:
 	await mainWindow.loadURL('app://-');
@@ -80,6 +80,23 @@ Type: `string`\
 Default: [`electron.session.defaultSession`](https://electronjs.org/docs/api/session#sessiondefaultsession)
 
 The [partition](https://electronjs.org/docs/api/session#sessionfrompartitionpartition-options) the protocol should be installed to, if you're not using Electron's default partition.
+
+### loadUrl(window, searchParams?)
+
+The `serve` function returns a `loadUrl` function, which you use to serve your HTML file in that window.
+
+##### window
+
+*Required*\
+Type: `BrowserWindow`\
+
+The window to load the file in.
+
+##### searchParams
+
+Type: `object`\
+
+Key value pairs to set as the query parameters.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,8 @@ let mainWindow;
 	mainWindow = new BrowserWindow();
 
 	await loadURL(mainWindow);
-	// Or optionally with query params
+
+	// Or optionally with search parameters.
 	await loadURL(mainWindow, {id: 4, foo: 'bar'});
 
 	// The above is equivalent to this:
@@ -103,7 +104,7 @@ The window to load the file in.
 
 Type: `object | URLSearchParams`
 
-Key value pairs or an [`URLSearchParams` instance](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) to set as the query parameters.
+Key value pairs or an [`URLSearchParams` instance](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) to set as the search parameters.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ Default: [`electron.session.defaultSession`](https://electronjs.org/docs/api/ses
 
 The [partition](https://electronjs.org/docs/api/session#sessionfrompartitionpartition-options) the protocol should be installed to, if you're not using Electron's default partition.
 
-### loadUrl(window, searchParams?)
+### loadUrl(window, searchParameters?)
 
 The `serve` function returns a `loadUrl` function, which you use to serve your HTML file in that window.
 

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ let mainWindow;
 
 ## API
 
-### serve(options)
+### loadUrl = serve(options)
 
 #### options
 
@@ -101,9 +101,9 @@ The window to load the file in.
 
 ##### searchParameters
 
-Type: `object`\
+Type: `object | URLSearchParams`
 
-Key value pairs to set as the query parameters.
+Key value pairs or an [`URLSearchParams` instance](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) to set as the query parameters.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,8 @@ let mainWindow;
 	mainWindow = new BrowserWindow();
 
 	await loadURL(mainWindow);
+	// Or optionally with query params
+	await loadURL(mainWindow, 'id=4&foo=bar');
 
 	// The above is equivalent to this:
 	await mainWindow.loadURL('app://-');

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ Type: `BrowserWindow`\
 
 The window to load the file in.
 
-##### searchParams
+##### searchParameters
 
 Type: `object`\
 

--- a/test/fixture-search-params.js
+++ b/test/fixture-search-params.js
@@ -1,0 +1,15 @@
+'use strict';
+const {app, BrowserWindow} = require('electron');
+const {join} = require('path');
+const serve = require('..');
+
+const loadUrl = serve({directory: join(__dirname, 'sub')});
+
+let mainWindow;
+
+(async () => {
+	await app.whenReady();
+
+	mainWindow = new BrowserWindow();
+	loadUrl(mainWindow, {id: 4, foo: 'bar'});
+})();

--- a/test/index 2.html
+++ b/test/index 2.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+	</head>
+	<body>
+		<h1>🚀</h1>
+	</body>
+</html>

--- a/test/sub/index.html
+++ b/test/sub/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<script>
+			const urlParams = new URLSearchParams(window.location.search);
+			const id = urlParams.get('id');
+			const foo = urlParams.get('foo');
+			document.getElementById('params').innerHTML = `${id}${foo}`;
+		</script>
+	</head>
+	<body>
+		<h1 id="params"></h1>
+	</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -65,3 +65,15 @@ test('throws error if unresolved path has an extension other than .html', async 
 	await t.throwsAsync(client.waitUntilTextExists('h1', '🦄', 5000));
 	t.pass();
 });
+
+test('serves directory index with search params', async t => {
+	t.context.spectron = new Application({
+		path: electron,
+		args: ['fixture-search-params.js']
+	});
+	await t.context.spectron.start();
+	const {client} = t.context.spectron;
+	await client.waitUntilWindowLoaded();
+	await client.waitUntilTextExists('h1', '4bar', 5000);
+	t.pass();
+});


### PR DESCRIPTION
In working on https://github.com/sindresorhus/electron-serve/pull/36, I also wanted the ability to pass in query parameters to different files. 

I added an example in the README since I didn't see any explicit documentation for the arguments for the returned function. Again, feel free to make any fixes or adjustments.